### PR TITLE
feat(format): add auto-formatting on save with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ brew install pandoc       # Markdown preview
 | Groovy     | groovy-mode        | -                              | (syntax highlighting only) |
 | C/C++      | c-ts-mode / c++-ts-mode | clangd                    | `xcode-select --install` or `brew install llvm` |
 | YAML       | yaml-ts-mode       | yaml-language-server (opt)     | `npm install -g yaml-language-server` |
+
+**Auto-formatting:** YAML files are automatically formatted on save using [apheleia](https://github.com/radian-software/apheleia) + [yamlfmt](https://github.com/google/yamlfmt). Install: `go install github.com/google/yamlfmt/cmd/yamlfmt@latest`
 | Markdown   | markdown-mode      | -                              | `brew install pandoc` (for preview) |
 
 **Tree-sitter modes** (`*-ts-mode`) provide accurate syntax highlighting. Grammars install via `M-x treesit-install-language-grammar`.
@@ -139,6 +141,9 @@ brew install ripgrep
 
 # Optional: Markdown support
 brew install pandoc
+
+# YAML auto-formatting
+go install github.com/google/yamlfmt/cmd/yamlfmt@latest
 
 # Terminal support (required for Claude Code)
 brew install libvterm
@@ -531,6 +536,7 @@ Built with these amazing packages:
 - [embark](https://github.com/oantolin/embark) - Contextual actions
 - [company](https://github.com/company-mode/company-mode) - Completion
 - [eglot](https://github.com/joaotavora/eglot) - LSP client
+- [apheleia](https://github.com/radian-software/apheleia) - Async code formatting on save
 - [claude-code.el](https://github.com/stevemolitor/claude-code.el) - Claude Code integration
 - [vterm](https://github.com/akermu/emacs-libvterm) - Terminal emulator
 
@@ -543,7 +549,7 @@ Built with these amazing packages:
 
 ---
 
-**Last Updated:** January 2026
+**Last Updated:** March 2026
 **Emacs Version:** 30.x
 **Status:** Production Ready
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ brew install pandoc       # Markdown preview
 | C/C++      | c-ts-mode / c++-ts-mode | clangd                    | `xcode-select --install` or `brew install llvm` |
 | YAML       | yaml-ts-mode       | yaml-language-server (opt)     | `npm install -g yaml-language-server` |
 
-**Auto-formatting:** YAML files are automatically formatted on save using [apheleia](https://github.com/radian-software/apheleia) + [yamlfmt](https://github.com/google/yamlfmt). Install: `go install github.com/google/yamlfmt/cmd/yamlfmt@latest`
+| JSON       | json-ts-mode       | -                              | (built-in) |
 | Markdown   | markdown-mode      | -                              | `brew install pandoc` (for preview) |
+
+**Auto-formatting on save:** TypeScript, TSX, YAML, and JSON files are automatically formatted on save using [apheleia](https://github.com/radian-software/apheleia) + [prettier](https://prettier.io/). Install: `npm install -g prettier`
 
 **Tree-sitter modes** (`*-ts-mode`) provide accurate syntax highlighting. Grammars install via `M-x treesit-install-language-grammar`.
 
@@ -142,8 +144,8 @@ brew install ripgrep
 # Optional: Markdown support
 brew install pandoc
 
-# YAML auto-formatting
-go install github.com/google/yamlfmt/cmd/yamlfmt@latest
+# Auto-formatting (TypeScript, TSX, YAML, JSON)
+npm install -g prettier
 
 # Terminal support (required for Claude Code)
 brew install libvterm

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ brew install pandoc       # Markdown preview
 | Groovy     | groovy-mode        | -                              | (syntax highlighting only) |
 | C/C++      | c-ts-mode / c++-ts-mode | clangd                    | `xcode-select --install` or `brew install llvm` |
 | YAML       | yaml-ts-mode       | yaml-language-server (opt)     | `npm install -g yaml-language-server` |
-
 | JSON       | json-ts-mode       | -                              | (built-in) |
 | Markdown   | markdown-mode      | -                              | `brew install pandoc` (for preview) |
 

--- a/init.el
+++ b/init.el
@@ -1014,6 +1014,7 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 ;; YAML Configuration
 ;; ============================================================
 ;; Optional LSP: npm install -g yaml-language-server
+;; Auto-formats on save using yamlfmt via apheleia
 
 ;; Use tree-sitter mode if grammar available, otherwise yaml-mode
 (if (my/treesit-available-p 'yaml)
@@ -1024,6 +1025,7 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
                 (lambda ()
                   (setq-local indent-tabs-mode nil)
                   (setq-local tab-width 2)
+                  (apheleia-mode 1)
                   (when (executable-find "yaml-language-server")
                     (eglot-ensure)))))
   ;; Fallback to yaml-mode package
@@ -1033,6 +1035,7 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
     :hook ((yaml-mode . (lambda ()
                           (setq-local indent-tabs-mode nil)
                           (setq-local tab-width 2)
+                          (apheleia-mode 1)
                           (when (executable-find "yaml-language-server")
                             (eglot-ensure)))))))
 
@@ -1119,20 +1122,10 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 ;; The "\\.kts\\'" pattern in kotlin configuration handles build.gradle.kts
 
 ;; ============================================================
-;; YAML Configuration
-;; ============================================================
-;; Uses built-in yaml-ts-mode (tree-sitter, Emacs 30+)
-;; Auto-formats on save using yamlfmt
-;; Install: go install github.com/google/yamlfmt/cmd/yamlfmt@latest
-
-(use-package yaml-ts-mode
-  :mode "\\.ya?ml\\'"
-  :hook (yaml-ts-mode . apheleia-mode))
-
-;; ============================================================
 ;; Auto-formatting on Save
 ;; ============================================================
 ;; Apheleia: async, diff-based formatter (cursor position preserved)
+;; Install: go install github.com/google/yamlfmt/cmd/yamlfmt@latest
 
 (use-package apheleia
   :ensure t
@@ -1140,6 +1133,8 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
   (setf (alist-get 'yamlfmt apheleia-formatters)
         '("yamlfmt" "-"))
   (setf (alist-get 'yaml-ts-mode apheleia-mode-alist)
+        'yamlfmt)
+  (setf (alist-get 'yaml-mode apheleia-mode-alist)
         'yamlfmt))
 
 ;; ============================================================

--- a/init.el
+++ b/init.el
@@ -989,11 +989,13 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 (if (my/treesit-available-p 'typescript)
     (progn
       (add-to-list 'auto-mode-alist '("\\.ts\\'" . typescript-ts-mode))
-      (add-hook 'typescript-ts-mode-hook 'eglot-ensure))
+      (add-hook 'typescript-ts-mode-hook 'eglot-ensure)
+      (add-hook 'typescript-ts-mode-hook 'apheleia-mode))
   ;; Fallback to typescript-mode package
   (use-package typescript-mode
     :mode "\\.ts\\'"
-    :hook (typescript-mode . eglot-ensure)
+    :hook ((typescript-mode . eglot-ensure)
+           (typescript-mode . apheleia-mode))
     :custom
     (typescript-indent-level 2)))
 
@@ -1001,11 +1003,13 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 (if (my/treesit-available-p 'tsx)
     (progn
       (add-to-list 'auto-mode-alist '("\\.tsx\\'" . tsx-ts-mode))
-      (add-hook 'tsx-ts-mode-hook 'eglot-ensure))
+      (add-hook 'tsx-ts-mode-hook 'eglot-ensure)
+      (add-hook 'tsx-ts-mode-hook 'apheleia-mode))
   ;; Fallback to web-mode for TSX
   (use-package web-mode
     :mode "\\.tsx\\'"
-    :hook (web-mode . eglot-ensure)
+    :hook ((web-mode . eglot-ensure)
+           (web-mode . apheleia-mode))
     :custom
     (web-mode-markup-indent-offset 2)
     (web-mode-code-indent-offset 2)))
@@ -1014,7 +1018,7 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 ;; YAML Configuration
 ;; ============================================================
 ;; Optional LSP: npm install -g yaml-language-server
-;; Auto-formats on save using yamlfmt via apheleia
+;; Auto-formats on save using prettier via apheleia
 
 ;; Use tree-sitter mode if grammar available, otherwise yaml-mode
 (if (my/treesit-available-p 'yaml)
@@ -1038,6 +1042,16 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
                           (apheleia-mode 1)
                           (when (executable-find "yaml-language-server")
                             (eglot-ensure)))))))
+
+;; ============================================================
+;; JSON Configuration
+;; ============================================================
+;; Uses built-in json-ts-mode (tree-sitter, Emacs 30+)
+;; Auto-formats on save using prettier via apheleia
+
+(when (my/treesit-available-p 'json)
+  (add-to-list 'auto-mode-alist '("\\.json\\'" . json-ts-mode))
+  (add-hook 'json-ts-mode-hook 'apheleia-mode))
 
 ;; ============================================================
 ;; Java Configuration
@@ -1125,17 +1139,18 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 ;; Auto-formatting on Save
 ;; ============================================================
 ;; Apheleia: async, diff-based formatter (cursor position preserved)
-;; Install: go install github.com/google/yamlfmt/cmd/yamlfmt@latest
+;; Requires: npm install -g prettier
 
 (use-package apheleia
   :ensure t
   :config
-  (setf (alist-get 'yamlfmt apheleia-formatters)
-        '("yamlfmt" "-"))
-  (setf (alist-get 'yaml-ts-mode apheleia-mode-alist)
-        'yamlfmt)
-  (setf (alist-get 'yaml-mode apheleia-mode-alist)
-        'yamlfmt))
+  ;; Use prettier for TypeScript, TSX, YAML, and JSON
+  (setf (alist-get 'typescript-ts-mode apheleia-mode-alist) 'prettier-typescript)
+  (setf (alist-get 'tsx-ts-mode apheleia-mode-alist) 'prettier-typescript)
+  (setf (alist-get 'yaml-ts-mode apheleia-mode-alist) 'prettier-yaml)
+  (setf (alist-get 'yaml-mode apheleia-mode-alist) 'prettier-yaml)
+  (setf (alist-get 'json-ts-mode apheleia-mode-alist) 'prettier-json)
+  (setf (alist-get 'json-mode apheleia-mode-alist) 'prettier-json))
 
 ;; ============================================================
 ;; Markdown Configuration

--- a/init.el
+++ b/init.el
@@ -977,6 +977,24 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 (setq js-indent-level 2)
 
 ;; ============================================================
+;; Auto-formatting on Save
+;; ============================================================
+;; Apheleia: async, diff-based formatter (cursor position preserved)
+;; Requires: npm install -g prettier
+
+(use-package apheleia
+  :ensure t
+  :config
+  ;; Use prettier for TypeScript, TSX, YAML, and JSON
+  (setf (alist-get 'typescript-ts-mode apheleia-mode-alist) 'prettier-typescript)
+  (setf (alist-get 'tsx-ts-mode apheleia-mode-alist) 'prettier-typescript)
+  (setf (alist-get 'yaml-ts-mode apheleia-mode-alist) 'prettier-yaml)
+  (setf (alist-get 'yaml-mode apheleia-mode-alist) 'prettier-yaml)
+  (setf (alist-get 'json-ts-mode apheleia-mode-alist) 'prettier-json)
+  (setf (alist-get 'json-mode apheleia-mode-alist) 'prettier-json)
+  (setf (alist-get 'js-json-mode apheleia-mode-alist) 'prettier-json))
+
+;; ============================================================
 ;; TypeScript Configuration
 ;; ============================================================
 ;; Uses typescript-ts-mode if grammar available, otherwise typescript-mode
@@ -1025,21 +1043,21 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
     (progn
       (add-to-list 'auto-mode-alist '("\\.ya?ml\\'" . yaml-ts-mode))
       (add-to-list 'auto-mode-alist '("\\.eyaml\\'" . yaml-ts-mode))
+      (add-hook 'yaml-ts-mode-hook 'apheleia-mode)
       (add-hook 'yaml-ts-mode-hook
                 (lambda ()
                   (setq-local indent-tabs-mode nil)
                   (setq-local tab-width 2)
-                  (apheleia-mode 1)
                   (when (executable-find "yaml-language-server")
                     (eglot-ensure)))))
   ;; Fallback to yaml-mode package
   (use-package yaml-mode
     :mode (("\\.ya?ml\\'" . yaml-mode)
            ("\\.eyaml\\'" . yaml-mode))
-    :hook ((yaml-mode . (lambda ()
+    :hook ((yaml-mode . apheleia-mode)
+           (yaml-mode . (lambda ()
                           (setq-local indent-tabs-mode nil)
                           (setq-local tab-width 2)
-                          (apheleia-mode 1)
                           (when (executable-find "yaml-language-server")
                             (eglot-ensure)))))))
 
@@ -1134,23 +1152,6 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 
 ;; For .gradle.kts files, use Kotlin mode (already configured above)
 ;; The "\\.kts\\'" pattern in kotlin configuration handles build.gradle.kts
-
-;; ============================================================
-;; Auto-formatting on Save
-;; ============================================================
-;; Apheleia: async, diff-based formatter (cursor position preserved)
-;; Requires: npm install -g prettier
-
-(use-package apheleia
-  :ensure t
-  :config
-  ;; Use prettier for TypeScript, TSX, YAML, and JSON
-  (setf (alist-get 'typescript-ts-mode apheleia-mode-alist) 'prettier-typescript)
-  (setf (alist-get 'tsx-ts-mode apheleia-mode-alist) 'prettier-typescript)
-  (setf (alist-get 'yaml-ts-mode apheleia-mode-alist) 'prettier-yaml)
-  (setf (alist-get 'yaml-mode apheleia-mode-alist) 'prettier-yaml)
-  (setf (alist-get 'json-ts-mode apheleia-mode-alist) 'prettier-json)
-  (setf (alist-get 'json-mode apheleia-mode-alist) 'prettier-json))
 
 ;; ============================================================
 ;; Markdown Configuration

--- a/init.el
+++ b/init.el
@@ -1119,6 +1119,30 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
 ;; The "\\.kts\\'" pattern in kotlin configuration handles build.gradle.kts
 
 ;; ============================================================
+;; YAML Configuration
+;; ============================================================
+;; Uses built-in yaml-ts-mode (tree-sitter, Emacs 30+)
+;; Auto-formats on save using yamlfmt
+;; Install: go install github.com/google/yamlfmt/cmd/yamlfmt@latest
+
+(use-package yaml-ts-mode
+  :mode "\\.ya?ml\\'"
+  :hook (yaml-ts-mode . apheleia-mode))
+
+;; ============================================================
+;; Auto-formatting on Save
+;; ============================================================
+;; Apheleia: async, diff-based formatter (cursor position preserved)
+
+(use-package apheleia
+  :ensure t
+  :config
+  (setf (alist-get 'yamlfmt apheleia-formatters)
+        '("yamlfmt" "-"))
+  (setf (alist-get 'yaml-ts-mode apheleia-mode-alist)
+        'yamlfmt))
+
+;; ============================================================
 ;; Markdown Configuration
 ;; ============================================================
 ;; Optional: brew install pandoc (for preview/export)


### PR DESCRIPTION
## Summary
- Add [apheleia](https://github.com/radian-software/apheleia) for async, diff-based auto-formatting on save using [prettier](https://prettier.io/)
- Supported file types: TypeScript, TSX, YAML, and JSON
- Cursor position is preserved during formatting (same UX as VS Code/Cursor)
- Both tree-sitter modes and fallback modes are covered
- Update README with new dependency, language table, and acknowledgments

## Prerequisites
```sh
npm install -g prettier
```

## Test plan
- [ ] Restart Emacs and confirm `apheleia` is installed automatically
- [ ] Open a YAML file, save with bad formatting, confirm it auto-formats
- [ ] Open a `.ts` file, save with bad formatting, confirm it auto-formats
- [ ] Open a `.json` file, save with bad formatting, confirm it auto-formats
- [ ] Verify cursor position is preserved after formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)