### PR TITLE
feat(ui): add frame background transparency

### DIFF
--- a/init.el
+++ b/init.el
@@ -777,12 +777,14 @@ Position the cursor at it's beginning, according to the current mode."
 ;; Font configuration
 (when window-system
   (set-frame-font "Monaco-12" nil t)
-  (set-frame-parameter nil 'alpha 100))
+  ;; Frame transparency: (active . inactive) opacity percentage
+  (set-frame-parameter nil 'alpha '(92 . 88)))
 
 (setq default-frame-alist
   (append
    '((font . "Monaco-12") ;; Default Fontset
   (width . 140) (height . 50) ;; Window Size
+  (alpha . (92 . 88)) ;; Frame transparency (active . inactive)
   )
   default-frame-alist))
 

--- a/init.el
+++ b/init.el
@@ -780,6 +780,15 @@ Position the cursor at it's beginning, according to the current mode."
   ;; Frame transparency: (active . inactive) opacity percentage
   (set-frame-parameter nil 'alpha '(92 . 88)))
 
+;; Terminal transparency: don't paint a background in TTY frames so the
+;; terminal emulator's own (transparent) background shows through.
+;; The actual opacity level is configured in the terminal app settings.
+(defun my/tty-transparent-background (&optional frame)
+  (unless (display-graphic-p frame)
+    (set-face-background 'default "unspecified-bg" frame)))
+(add-hook 'window-setup-hook #'my/tty-transparent-background)
+(add-hook 'after-make-frame-functions #'my/tty-transparent-background)
+
 (setq default-frame-alist
   (append
    '((font . "Monaco-12") ;; Default Fontset


### PR DESCRIPTION
## Summary
- Change frame alpha from fully opaque (100) to 92% when the frame is active and 88% when inactive
- Add the alpha setting to `default-frame-alist` so newly created frames inherit the transparency

## Testing
- `check-parens` passes on init.el
- Restart Emacs (GUI) and confirm the frame background is slightly translucent; adjust the `(92 . 88)` values to taste

🤖 Generated with [Claude Code](https://claude.com/claude-code)