### PR TITLE
feat(terminal): add kkp for Kitty keyboard protocol support

### DIFF
--- a/init.el
+++ b/init.el
@@ -175,6 +175,24 @@
   (global-set-key [bottom-divider mouse-1] 'mouse-drag-mode-line))
 
 ;; ============================================================
+;; Terminal Keyboard: Kitty Keyboard Protocol (KKP)
+;; ============================================================
+;; Terminals and multiplexers that speak the Kitty keyboard protocol
+;; (Ghostty, Kitty, herdr panes) can deliver Ctrl/Alt-modified keys as
+;; CSI u escape sequences that stock terminal Emacs cannot decode,
+;; leaving those keys dead. kkp negotiates and decodes the protocol.
+;; It probes the terminal first, so it stays inactive in terminals
+;; without KKP support (iTerm2, Apple Terminal, plain SSH, etc.).
+(use-package kkp
+  :ensure t
+  :hook (tty-setup . global-kkp-mode)
+  :config
+  ;; While KKP is active, C-g arrives as an escape sequence instead of
+  ;; the raw quit byte, so it cannot abort blocking synchronous
+  ;; subprocess calls; restore legacy keys around those calls.
+  (setq kkp-restore-legacy-keys-around-subprocesses t))
+
+;; ============================================================
 ;; Terminal Vertical Split Display Fix
 ;; ============================================================
 ;; Prevent text overflow between vertically split windows in terminal


### PR DESCRIPTION
## Summary
- Add the `kkp` package (MELPA, github.com/benotn/kkp) so terminal Emacs can negotiate and decode the Kitty keyboard protocol (CSI u key encoding).
- Fixes Ctrl-modified keys (C-x, C-c, etc.) not being recognized when Emacs runs inside a herdr pane in Ghostty. herdr re-encodes keystrokes through libghostty-vt and advertises the Kitty protocol to pane apps, so Ctrl chords can arrive as sequences like `ESC[120;5u` that stock Emacs 30 cannot decode (see herdr issues [#33](https://github.com/ogulcancelik/herdr/issues/33) and [#956](https://github.com/ogulcancelik/herdr/issues/956)).

## Details
- Enabled via `tty-setup` hook, so it loads only for text-terminal frames (including `emacsclient -nw`).
- `global-kkp-mode` probes the terminal before activating, so it is inert in terminals without KKP support (iTerm2, Apple Terminal, plain SSH).
- `kkp-restore-legacy-keys-around-subprocesses` is set so C-g can still abort blocking synchronous subprocess calls while KKP is active.

## Test plan
- [ ] `emacs -nw` in a plain Ghostty tab: verify normal startup, no errors, Ctrl keys unchanged.
- [ ] `emacs -nw` inside a herdr pane: verify C-x, C-c and other Ctrl chords work.
- [ ] `M-x kkp-status` inside herdr: reports KKP active.
- [ ] GUI Emacs: verify startup is unaffected (package should not load).

Note: C-/ (undo) may still arrive as `/` inside herdr due to an open herdr bug ([#956](https://github.com/ogulcancelik/herdr/issues/956)); use C-x u or C-_ there until it is fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01342CTevfYEP4SCVFBht1K5