### PR TITLE
chore: suppress startup warning logs and ignore local redactors

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -2,3 +2,4 @@ tmp/
 settings.local.json
 metadata/
 logs/
+redactors/local/

--- a/init.el
+++ b/init.el
@@ -1354,7 +1354,8 @@ Uses treesit-ready-p which verifies the grammar can be loaded."
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
  '(company-show-quick-access t nil nil "Customized with use-package company")
- '(package-selected-packages nil))
+ '(package-selected-packages nil)
+ '(warning-suppress-log-types '((use-package) (comp) (bytecomp))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
## Summary

Two independent housekeeping changes, one per commit.

**`chore(init)`** Adds `warning-suppress-log-types` to `custom-set-variables` covering `use-package`, `comp`, and `bytecomp`. Routine native-compilation, byte-compilation, and use-package warnings no longer accumulate in the `*Warnings*` buffer at startup.

**`chore(entire)`** Adds `redactors/local/` to `.entire/.gitignore` so local-only redactor config stays untracked.

## Test plan

- [x] `init.el` parses cleanly (185 top-level forms read without error)
- [ ] Restart Emacs and confirm no startup errors
- [ ] Confirm the `*Warnings*` buffer stays quiet on a fresh start

## SemVer impact

None. Both commits are `chore` and change no user-facing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAeRFbgGYi4PuU1S8zUBuY